### PR TITLE
Update github location

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ doc = [
 
 [project.urls]
 Homepage = "https://usnan.nmrhub.org"
-Repository = "https://github.com/usnan/usnan-sdk"
+Repository = "https://github.com/NanNMR/PythonSDK"
 
 [tool.setuptools.packages.find]
 exclude = ["build*", "source*"]


### PR DESCRIPTION
The https://pypi.org/project/usnan/ "Repository" link is 404. I think this will fix it on the next push.